### PR TITLE
Adding locking to the Spectator and SpectatorConnection classes.

### DIFF
--- a/pyhelix/spectator.py
+++ b/pyhelix/spectator.py
@@ -191,7 +191,7 @@ class Spectator(object):
                 for participant_id, s in self._mapping[partition_id].iteritems():
                     if s == state:
                         result.add(participant_id)
-                return [self._participants[p] for p in result]
+        return [self._participants[p] for p in result]
 
     def get_state_map(self, partition_id):
         """


### PR DESCRIPTION
This is required as the data accessor class uses kazoo.recipe.watchers classes which spawn threads to watch for changes in zookeeper state. These threads will call the callbacks such as _pc_watcher or _ev_watcher. This can cause a race condition when an accessor such as Spectator.get_participants is called. Specifically, the case we experience is a loss of connectivity to zookeeper which triggers a reset (SpectatorConnection._init() calls self._participants.clear()) which then causes Spectator.get_partitipants to throw a keyError on line 194 (return [self._participants[p] for p in result]). The locking being added should prevent these cases from occuring.