### PR TITLE
Fix initialization of new instances by avoiding a TypeError

### DIFF
--- a/pyhelix/keybuilder.py
+++ b/pyhelix/keybuilder.py
@@ -75,9 +75,9 @@ class KeyBuilder(object):
             self._cluster_id, participant_id, session_id, resource_id)
 
     @propertykey(merge_on_update=True)
-    def errors(self, participant_id, session_id, resource_id):
-        return '/{0}/INSTANCES/{1}/ERRORS/{2}/{3}'.format(
-            self._cluster_id, participant_id, session_id, resource_id)
+    def errors(self, participant_id):
+        return '/{0}/INSTANCES/{1}/ERRORS'.format(
+            self._cluster_id, participant_id)
 
     @propertykey(merge_on_update=True)
     def error(self, participant_id, session_id, resource_id, partition_id):


### PR DESCRIPTION
Problem:

1) When we start this on a new instance, it will check to see if
   CONFIGS/PARTICIPANT/{host} exists. If it doesn't, it proceeds
   to create all of the needed znodes under INSTANCES/{host}

2) As it tries creating the nodes under INSTANCES/{host}, one of
   the functions it uses raises TypeError as it wasn't passed enough
   arguments.

3) As 1 already ran, the needed nodes under INSTANCES/{host} will
   never exist, which is what leads to us needing to manually create
   them to avoid a NoNodeError.

Fix:

- Fix the keybuilder `errors` helper as it looks to be a broken copy/paste
  problem, in that it's identical to `error` and only used in this one
  spot.